### PR TITLE
Fix edit link when `repositoryURL` does not end in `/`

### DIFF
--- a/smooth-doc/gatsby-node.js
+++ b/smooth-doc/gatsby-node.js
@@ -140,7 +140,7 @@ function onCreateMdxNode({ node, getNode, actions }, options) {
       baseDirectory,
       '',
     )
-    return new URL(`edit/${githubDefaultBranch}${relativePath}`, repositoryURL).toString()
+    return new URL(`blob/edit/${githubDefaultBranch}${relativePath}`, repositoryURL).toString()
   }
 
   createNodeField({

--- a/smooth-doc/gatsby-node.js
+++ b/smooth-doc/gatsby-node.js
@@ -140,7 +140,7 @@ function onCreateMdxNode({ node, getNode, actions }, options) {
       baseDirectory,
       '',
     )
-    return `${repositoryURL}edit/${githubDefaultBranch}${relativePath}`
+    return new URL(`edit/${githubDefaultBranch}${relativePath}`, repositoryURL).toString()
   }
 
   createNodeField({


### PR DESCRIPTION
The "Edit this page on GitHub" at https://react-svgr.com/docs/node-api/ is broken.
- https://react-svgr.com/docs/node-api/
- Wrong `https://github.com/gregberge/svgredit/main/website/pages/docs/node-api.mdx`
- Right `https://github.com/gregberge/svgr/blob/main/website/pages/docs/node-api.mdx`

This change should make sure that the `repositoryURL` is always merged with the path with one but just one `/`.
It also adds the missing `blob`.

---

Disclaimer: I did not test this code, just edited in Github.